### PR TITLE
editorial changes

### DIFF
--- a/iswc-2019.html
+++ b/iswc-2019.html
@@ -22,18 +22,18 @@
           <section id="general-guidance" inlist="" rel="schema:hasPart" resource="general-guidance">
             <h2 proprety="schema:name">General Guidance</h2>
             <div property="schema:description">
-              <p>Contributions in HTML should be shared in EasyChair as a ZIP archive that contains the complete content of the article. It should include a main “index.html” and all used resources (like media, scripts) to guarantee a correct visualisation of the document on common desktop and mobile Web browsers. Please note the following key requirements:</p>
+              <p>Contributions in HTML should be shared in EasyChair as a ZIP archive that contains the complete content of the article. It should include a main “index.html” and all used resources (like media, scripts) to guarantee a correct visualization of the document on common desktop and mobile Web browsers. Please note the following key requirements:</p>
 
               <ul>
                 <li>HTML template: any tooling or process can be used to produce the HTML.</li>
 
-                <li>Content: the articles' full content must be human-readable with HTML alone. The use of CSS and JavaScript is encouraged, but should not interfere with the accessibility of the content.</li>
+                <li>Content: the full content of the article must be human-readable with HTML alone. The use of CSS and JavaScript is encouraged, but should not interfere with the accessibility of the content.</li>
 
-                <li>Offline-friendly: there must be no external dependencies (eg a network connection) to retrieve, render, or manipulate the content's of the article.</li>
+                <li>Offline-friendly: there must not be any external dependencies (e.g., a network connection) to retrieve, to render, or to manipulate the content of the article.</li>
 
                 <li>Privacy: scripts must not be used to identify or track readers.</li>
 
-                <li>View: the rendered article (HTML+CSS) should have the "look and feel" of the LNCS authoring guidelines. Pixel-perfection is not expected. This is to ensure visual consistency of the proceedings as well as to have comparative page limits with the print-based publication.</li>
+                <li>View: the rendered article (HTML+CSS) should have the "look and feel" of the LNCS authoring guidelines. Pixel-perfection is not expected. This is to ensure visual consistency of the proceedings as well as to have comparative page limits with the print-based publication. The HTML article has to be compliant with the page limit constraint.</li>
               </ul>
 
               <p>It should be possible to read the HTML contributions on an average desktop computer or mobile computer that is equipped with a reasonably current, Javascript-enabled Web browser (e.g., Firefox, Chrome/Chromium, Internet Explorer, Brave, Safari). We encourage authors to make their articles as accessible as possible (for reading and interacting) because different consumers (in this case initially the reviewers and chairs) may have different environments and abilities.</p>
@@ -46,7 +46,7 @@
               <p>Formatting requirements for the <em>final version</em> differ by call.</p>
 
               <ul>
-                <li>Articles accepted in the <cite>Research, In-Use, and Resources tracks</cite> will be published by Springer in the printed conference proceedings, as a part of the Lecture Notes in Computer Science (LNCS) series. Springer requires the sources of papers that have been accepted for publication in <a href="http://www.springer.com/de/it-informatik/lncs/conference-proceedings-guidelines">LaTeX or Word format</a>. If an article submitted in HTML is accepted, the authors can choose to do this step manually or using tool support as outlined below.</li>
+                <li>Articles accepted in the <cite>Research, In-Use, and Resources tracks</cite> will be published by Springer in the printed conference proceedings, as a part of the Lecture Notes in Computer Science (LNCS) series. Springer requires the sources of articles that have been accepted for publication in <a href="http://www.springer.com/de/it-informatik/lncs/conference-proceedings-guidelines">LaTeX or Word format</a>. If an article submitted in HTML is accepted, the authors can choose to do this step manually or using tool support as outlined below.</li>
 
                 <li>Articles accepted in the <cite>Posters &amp; Demos track</cite> and in the <cite>Doctoral Consortium</cite> will be published as <a href="http://CEUR-WS.org/">CEUR-WS.org</a> proceedings volumes. CEUR-WS.org allows articles to be in HTML but, for guaranteed printability and archiving, requires an additional PDF, which should be a print-out of the HTML article in the LNCS layout.</li>
 
@@ -58,7 +58,7 @@
           <section id="recommendations" inlist="" rel="schema:hasPart" resource="recommendations">
             <h2 proprety="schema:name">Recommendations</h2>
             <div property="schema:description">
-              <p>We recommend that authors take these steps independently of the general process:</p>
+              <p>We recommend that authors take the following steps independently of the general process:</p>
 
               <p>Before sharing your article with ISWC, self-publish your HTML version, eg. at a repository, personal or institution website that's publicly accessible and archivable from a URL.</p>
 
@@ -70,20 +70,20 @@
 
               <p>If you intend to also publish the "Author’s Accepted Manuscript" version following peer-review, note Springer's <a href="https://www.springer.com/gb/open-access/authors-rights/self-archiving-policy/2124">self-archiving policy</a>.</p>
 
-              <p>Send a notification about your original self-published article to the <a href="https://linkedresearch.org">Linked Open Research Cloud</a> (<abbr title="Linked Open Research Cloud">LORC</abbr>) so to improve its discoverability.</p>
+              <p>Send a notification about your original self-published article to the <a href="https://linkedresearch.org">Linked Open Research Cloud</a> (<abbr title="Linked Open Research Cloud">LORC</abbr>) to improve the discoverability of your article.</p>
 
               <p>For additional help, authors are welcome to <a href="https://gitter.im/linkedresearch/chat">join the public chat</a> on <a href="https://linkedresearch.org/">Linked Research</a>. Please note that this not an official communication channel of the conference. It is an open community for scholarly communication and people passionate about the Web.</p>
 
-              <p>Authors are encouraged to use tooling and processes that best works for them.</p>
+              <p>Authors are encouraged to use tooling and processes that work best for them.</p>
 
               <section id="dokieli" inlist="" rel="schema:hasPart" resource="dokieli">
                 <h3 proprety="schema:name">dokieli</h3>
                 <div property="schema:description">
                   <p><a href="https://dokie.li/">dokieli</a> is a client-side editor for decentralized article publishing in HTML+RDF annotations, notifications, and social interactions. It implements W3C Recommendations like <a href="https://www.w3.org/TR/annotation-model/">Web Annotation</a>, <a href="https://www.w3.org/TR/ldn/">Linked Data Notifications</a>, and <a href="https://www.w3.org/TR/activitypub/">ActivityPub</a>.</p>
 
-                  <p>The <a href="https://dokie.li/lncs-splnproc">LNCS author guidelines</a> can be used as template. View source. There is a list of <a href="https://github.com/linkeddata/dokieli/wiki#examples-in-the-wild">examples in the wild</a>.</p>
+                  <p>The <a href="https://dokie.li/lncs-splnproc">LNCS author guidelines</a> can be used as template. There is a list of <a href="https://github.com/linkeddata/dokieli/wiki#examples-in-the-wild">examples in the wild</a>.</p>
 
-                  <p>Authors that would like to self-publish, can use any HTTP server. Authors, reviewers, and readers can use their own <a href="https://www.w3.org/2005/Incubator/webid/spec/">WebID</a> and Linked Data based personal storages, eg. <a href="http://github.com/solid/node-solid-server/">Solid</a>, with dokieli. <a href="https://gitter.im/linkeddata/dokieli">Join the chat</a> for any help.</p>
+                  <p>Authors that would like to self-publish can use any HTTP server. Authors, reviewers, and readers can use their own <a href="https://www.w3.org/2005/Incubator/webid/spec/">WebID</a> and Linked Data based personal storages, eg. <a href="http://github.com/solid/node-solid-server/">Solid</a>, with dokieli. <a href="https://gitter.im/linkeddata/dokieli">Join the chat</a> if you need help.</p>
                 </div>
               </section>
 


### PR DESCRIPTION
I propose to change the content of the guide using the changes in the given commit.

Besides these changes, I wonder why you did not copy the two bullet points in the dokieli subsection of [the ESWC 2019 version of the guide](https://2019.eswc-conferences.org/html-submission-guide/). I think these two bullet points are really helpful. Is there any reason for not including them here?

